### PR TITLE
Relax constraint on prometheus_ex and upgrade absinthe

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule AbsintheMetrics.Mixfile do
       app: :absinthe_metrics,
       version: "0.9.0",
       elixir: "~> 1.4",
-      start_permanent: Mix.env == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),
       package: package(),
@@ -25,9 +25,9 @@ defmodule AbsintheMetrics.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:absinthe, "~> 1.3"},
-      {:prometheus_ex, "~> 1.4", optional: true},
-      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:absinthe, "~> 1.4"},
+      {:prometheus_ex, ">= 1.4.0", optional: true},
+      {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,7 @@
-%{"absinthe": {:hex, :absinthe, "1.3.2", "1d16ee5ceeb8b90e37f936b924caacc099b9da667e9c7e6a4d729f41197123d4", [], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.3", "cd2a4cfe5d26e37502d3ec776702c72efa1adfa24ed9ce723bb565f4c30bd31a", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "prometheus": {:hex, :prometheus, "3.4.0", "91759726f2e384df2ef48daf039d506705a7aa81dcbbb2dbffee1fd0c5431d32", [], [], "hexpm"},
-  "prometheus_ex": {:hex, :prometheus_ex, "1.4.1", "5e08decec6f925c296b99eb136b40e8dacdedd9f03553575ee88a38a23ce9601", [], [{:prometheus, "~> 3.4", [hex: :prometheus, repo: "hexpm", optional: false]}], "hexpm"}}
+%{
+  "absinthe": {:hex, :absinthe, "1.4.13", "81eb2ff41f1b62cd6e992955f62c22c042d1079b7936c27f5f7c2c806b8fc436", [:mix], [{:dataloader, "~> 1.0.0", [hex: :dataloader, repo: "hexpm", optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.16.3", "cd2a4cfe5d26e37502d3ec776702c72efa1adfa24ed9ce723bb565f4c30bd31a", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "prometheus": {:hex, :prometheus, "4.2.0", "06c58bfdfe28d3168b926da614cb9a6d39593deebde648a5480e32dfa3c370e9", [:mix, :rebar3], [], "hexpm"},
+  "prometheus_ex": {:hex, :prometheus_ex, "3.0.3", "5d722263bb1f7a9b1d02554de42e61ea672b4e3c07c3f74e23ce35ab5e111cfa", [:mix], [{:prometheus, "~> 4.0", [hex: :prometheus, repo: "hexpm", optional: false]}], "hexpm"},
+}


### PR DESCRIPTION
There are two reasons for this:

* prometheus_ex is so far behind that mix is preventing us including this in our application
* absinthe needs updating for the tests to work on modern elixir

I've checked and neither of these appear to be problematic given the usage